### PR TITLE
auto-complete words that contain a term

### DIFF
--- a/src/main/java/org/scijava/ui/swing/script/autocompletion/JythonAutocompletionProvider.java
+++ b/src/main/java/org/scijava/ui/swing/script/autocompletion/JythonAutocompletionProvider.java
@@ -219,12 +219,12 @@ public class JythonAutocompletionProvider extends DefaultCompletionProvider {
 					final ArrayList<Completion> completions = new ArrayList<>();
 					for (final Field f: c.getFields()) {
 						if (isStatic == Modifier.isStatic(f.getModifiers()) &&
-								(includeAll || f.getName().toLowerCase().startsWith(methodOrFieldSeed)))
+								(includeAll || f.getName().toLowerCase().contains(methodOrFieldSeed)))
 							completions.add(getCompletion(pre, f, c));
 					}
 					for (final Method m: c.getMethods()) {
 						if (isStatic == Modifier.isStatic(m.getModifiers()) &&
-								(includeAll || m.getName().toLowerCase().startsWith(methodOrFieldSeed)))
+								(includeAll || m.getName().toLowerCase().contains(methodOrFieldSeed)))
 						completions.add(getCompletion(pre+m.getName(), m, c));
 					}
 					return completions;


### PR DESCRIPTION
Hi @tferr , CC-hi @acardona ,

here comes a mini-PR: CLIJ users like searching for terms like "otsu" and see auto-completion suggestions like "thresholdOtsu". This can be achieved in your Auto-Completion with this little PR.

![image](https://user-images.githubusercontent.com/12660498/101201386-f67f4780-3667-11eb-86c0-480633f213e3.png)

Let me know what you think!

Cheers,
Robert
